### PR TITLE
Custom context metadata object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin/
 obj/
 artifacts/
+*.csproj.user

--- a/examples/Example.AspCore/Commands/CustomContext.cs
+++ b/examples/Example.AspCore/Commands/CustomContext.cs
@@ -1,0 +1,22 @@
+﻿namespace Example.AspCore.Commands
+{
+    /// <summary>
+    /// My custom command context.
+    /// </summary>
+    internal class CustomContext
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomContext"/> class.
+        /// </summary>
+        /// <param name="username">The name of the requesting user.</param>
+        public CustomContext(string username)
+        {
+            this.Username = username;
+        }
+
+        /// <summary>
+        ///  Gets the name of the requesting user.
+        /// </summary>
+        public string Username { get; }
+    }
+}

--- a/examples/Example.AspCore/Commands/Test/TestCommandHandler.cs
+++ b/examples/Example.AspCore/Commands/Test/TestCommandHandler.cs
@@ -11,7 +11,8 @@
         /// <inheritdoc />
         public Task HandleAsync(TestCommand command, CommandMetadata metadata)
         {
-            Console.WriteLine($"TEST COMMAND: {command.Message}");
+            var ctx = metadata.GetContext<CustomContext>();
+            Console.WriteLine($"TEST COMMAND: {command.Message} | User: '{ctx?.Username}'");
             return Task.CompletedTask;
         }
     }

--- a/examples/Example.AspCore/Example.AspCore.csproj
+++ b/examples/Example.AspCore/Example.AspCore.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandApi" Version="1.0.0" />
+    <PackageReference Include="CommandApi" Version="1.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/examples/Example.AspCore/GlobalSuppressions.cs
+++ b/examples/Example.AspCore/GlobalSuppressions.cs
@@ -1,6 +1,6 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage 
+﻿// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "<Pending>", Scope = "type", Target = "T:Example.AspCore.Program")]

--- a/examples/Example.AspCore/Startup.cs
+++ b/examples/Example.AspCore/Startup.cs
@@ -28,6 +28,14 @@ namespace Example.AspCore
                 new List<Assembly>
                 {
                     typeof(Startup).Assembly,
+                },
+                opts =>
+                {
+                    opts.SetCustomContext = (http, info) =>
+                    {
+                        var user = http.User?.Identity?.Name ?? "<none>";
+                        return new Commands.CustomContext(user);
+                    };
                 });
         }
 

--- a/src/CommandApi/CommandApi.csproj
+++ b/src/CommandApi/CommandApi.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
 
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Title>CQRS Command API</Title>
     <RepositoryType>git</RepositoryType>
     <Authors>Alex McNair</Authors>

--- a/src/CommandApi/CommandBusOptions.cs
+++ b/src/CommandApi/CommandBusOptions.cs
@@ -3,6 +3,8 @@
     using System;
     using System.Threading.Tasks;
 
+    using Microsoft.AspNetCore.Http;
+
     /// <summary>
     /// Options for the command processing pipeline.
     /// </summary>
@@ -27,5 +29,12 @@
         /// when authorization fails.
         /// </summary>
         public Func<CommandMetadata, Task>? OnAuthorizationFailed { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional delegate that is invoked with each web request
+        /// to generate a custom context that will be added to the <see cref="CommandMetadata"/>
+        /// object.
+        /// </summary>
+        public Func<HttpContext, CommandRequestInfo, dynamic>? SetCustomContext { get; set; }
     }
 }

--- a/src/CommandApi/CommandRequestInfo.cs
+++ b/src/CommandApi/CommandRequestInfo.cs
@@ -1,0 +1,59 @@
+﻿namespace CommandApi
+{
+    using System;
+
+    /// <summary>
+    /// Represents information about an incoming command request.
+    /// </summary>
+    public class CommandRequestInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommandRequestInfo"/> class.
+        /// </summary>
+        /// <param name="commandName">The name of the command being handled.</param>
+        /// <param name="timestamp">The time the command was received.</param>
+        /// <param name="correlationId">The request correlation identifier.</param>
+        /// <param name="validateOnly">Whether the command should be validated, or validated and executed.</param>
+        public CommandRequestInfo(
+            string commandName,
+            DateTime timestamp,
+            string correlationId,
+            bool validateOnly)
+        {
+            if (string.IsNullOrWhiteSpace(commandName))
+            {
+                throw new ArgumentNullException(nameof(commandName));
+            }
+
+            if (string.IsNullOrWhiteSpace(correlationId))
+            {
+                throw new ArgumentNullException(nameof(correlationId));
+            }
+
+            this.CommandName = commandName;
+            this.Timestamp = timestamp;
+            this.CorrelationId = correlationId;
+            this.ValidateOnly = validateOnly;
+        }
+
+        /// <summary>
+        /// Gets the command name.
+        /// </summary>
+        public string CommandName { get; }
+
+        /// <summary>
+        /// Gets the timestamp.
+        /// </summary>
+        public DateTime Timestamp { get; }
+
+        /// <summary>
+        /// Gets the correlation identifier.
+        /// </summary>
+        public string CorrelationId { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the command should be validated, or validated and executed.
+        /// </summary>
+        public bool ValidateOnly { get; }
+    }
+}

--- a/test/CommandApi.Tests/CommandMetadataTests.cs
+++ b/test/CommandApi.Tests/CommandMetadataTests.cs
@@ -1,0 +1,69 @@
+﻿namespace CommandApi.Tests
+{
+    using System;
+
+    using Xunit;
+
+    public class CommandMetadataTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void New_ThrowsWhenCommandNameIsInvalid(string value)
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new CommandMetadata(
+                    value,
+                    new DateTime(2021, 1, 1),
+                    "id"));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void New_ThrowsWhenCorrelationIdIsInvalid(string value)
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new CommandMetadata(
+                    "name",
+                    new DateTime(2021, 1, 1),
+                    value));
+        }
+
+        [Fact]
+        public void New_ValidParameteresAreAssignedCorrectly()
+        {
+            // Arrange / Act
+            var info = new CommandMetadata(
+                "name",
+                new DateTime(2021, 2, 2),
+                "id");
+
+            // Assert
+            Assert.Equal("name", info.CommandName);
+            Assert.Equal(new DateTime(2021, 2, 2), info.Timestamp);
+            Assert.Equal("id", info.CorrelationId);
+        }
+
+        [Fact]
+        public void New_ValidParameteresWithCustomContextAreAssignedCorrectly()
+        {
+            // Arrange / Act
+            var info = new CommandMetadata(
+                "name",
+                new DateTime(2021, 2, 2),
+                "id",
+                "test");
+
+            // Assert
+            Assert.Equal("name", info.CommandName);
+            Assert.Equal(new DateTime(2021, 2, 2), info.Timestamp);
+            Assert.Equal("id", info.CorrelationId);
+
+            Assert.NotNull(info.Context);
+            Assert.Equal("test", (string)info.Context);
+        }
+    }
+}

--- a/test/CommandApi.Tests/CommandRequestInfoTests.cs
+++ b/test/CommandApi.Tests/CommandRequestInfoTests.cs
@@ -1,0 +1,56 @@
+﻿namespace CommandApi.Tests
+{
+    using System;
+
+    using Xunit;
+
+    public class CommandRequestInfoTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void New_ThrowsWhenCommandNameIsInvalid(string value)
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new CommandRequestInfo(
+                    value,
+                    new DateTime(2021, 1, 1),
+                    "id",
+                    true));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void New_ThrowsWhenCorrelationIdIsInvalid(string value)
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new CommandRequestInfo(
+                    "name",
+                    new DateTime(2021, 1, 1),
+                    value,
+                    true));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void New_ValidParameteresAreAssignedCorrectly(bool validateOnly)
+        {
+            // Arrange / Act
+            var info = new CommandRequestInfo(
+                "name",
+                new DateTime(2021, 2, 2),
+                "id",
+                validateOnly);
+
+            // Assert
+            Assert.Equal("name", info.CommandName);
+            Assert.Equal(new DateTime(2021, 2, 2), info.Timestamp);
+            Assert.Equal("id", info.CorrelationId);
+            Assert.Equal(validateOnly, info.ValidateOnly);
+        }
+    }
+}

--- a/test/CommandApi.Tests/IntegrationTests/Infrastructure/TestStartupFactory.cs
+++ b/test/CommandApi.Tests/IntegrationTests/Infrastructure/TestStartupFactory.cs
@@ -6,7 +6,8 @@
     using Microsoft.AspNetCore.Mvc.Testing;
     using Microsoft.Extensions.Hosting;
 
-    public class TestStartupFactory : WebApplicationFactory<TestStartup>
+    public class TestStartupFactory<T> : WebApplicationFactory<T>
+        where T : class
     {
         protected override IHost CreateHost(IHostBuilder builder)
         {
@@ -20,7 +21,7 @@
                 Host.CreateDefaultBuilder()
                     .ConfigureWebHostDefaults(builder =>
                     {
-                        builder.UseStartup<TestStartup>();
+                        builder.UseStartup<T>();
                     });
         }
     }

--- a/test/CommandApi.Tests/IntegrationTests/Infrastructure/TestStartupWithCommandContext.cs
+++ b/test/CommandApi.Tests/IntegrationTests/Infrastructure/TestStartupWithCommandContext.cs
@@ -1,0 +1,82 @@
+﻿namespace CommandApi.Tests.IntegrationTests.Infrastructure
+{
+    using System.Collections.Generic;
+    using System.Net;
+
+    using CommandApi.DependencyInjection;
+
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.DependencyInjection;
+
+    public class TestStartupWithCommandContext
+    {
+        public TestStartupWithCommandContext()
+        {
+        }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // register the command bus
+            services.AddCommandBus(
+                new List<System.Reflection.Assembly>
+                {
+                    this.GetType().Assembly,
+                },
+                opts =>
+                {
+                    opts.SetCustomContext = (http, info) =>
+                    {
+                        var headers = http.Request.Headers;
+
+                        string user =
+                            headers.ContainsKey("x-user-id")
+                                ? headers["x-user-id"].ToString()
+                                : null;
+
+                        return new TestCustomContext(user, info.ValidateOnly);
+                    };
+                });
+
+            // register the helpers
+            services.AddSingleton<ICommandTrackingStore, CommandTrackingStore>();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapGet("/test-get", ctx =>
+                {
+                    ctx.Response.StatusCode = (int)HttpStatusCode.OK;
+                    return ctx.Response.WriteAsync("OK");
+                });
+
+                endpoints.MapGet("/bad-test-get", ctx =>
+                {
+                    ctx.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                    return ctx.Response.WriteAsync("Bad");
+                });
+
+                endpoints.MapCommandEndpoint();
+            });
+        }
+    }
+
+    public class TestCustomContext
+    {
+        public TestCustomContext(
+            string userIdHeader,
+            bool validateOnlyHeader)
+        {
+            this.UserIdHeader = userIdHeader;
+            this.ValidateOnlyHeader = validateOnlyHeader;
+        }
+
+        public string UserIdHeader { get; }
+
+        public bool ValidateOnlyHeader { get; }
+    }
+}

--- a/test/CommandApi.Tests/IntegrationTests/Tests/BasicCommandWithContextTests.cs
+++ b/test/CommandApi.Tests/IntegrationTests/Tests/BasicCommandWithContextTests.cs
@@ -16,16 +16,16 @@
 
     using Xunit;
 
-    public class BasicCommandTests :
-        IClassFixture<TestStartupFactory<TestStartup>>,
+    public class BasicCommandWithContextTests :
+        IClassFixture<TestStartupFactory<TestStartupWithCommandContext>>,
         IDisposable
     {
-        public BasicCommandTests(TestStartupFactory<TestStartup> factory)
+        public BasicCommandWithContextTests(TestStartupFactory<TestStartupWithCommandContext> factory)
         {
             this.Factory = factory;
         }
 
-        private TestStartupFactory<TestStartup> Factory { get; }
+        private TestStartupFactory<TestStartupWithCommandContext> Factory { get; }
 
         public void Dispose()
         {
@@ -98,6 +98,11 @@
             Assert.True(trackedCommand.Authorized);
             Assert.True(trackedCommand.Validated);
             Assert.True(trackedCommand.Handled);
+
+            var context = trackedCommand.Metadata.GetContext<TestCustomContext>();
+            Assert.NotNull(context);
+            Assert.Null(context.UserIdHeader);
+            Assert.False(context.ValidateOnlyHeader);
         }
 
         [Fact]
@@ -121,6 +126,7 @@
                 Headers =
                 {
                     { "x-validate-only", "true" },
+                    { "x-user-id", "123" },
                 },
                 Content = body,
             };
@@ -148,6 +154,11 @@
             Assert.True(trackedCommand.Authorized);
             Assert.True(trackedCommand.Validated);
             Assert.False(trackedCommand.Handled);
+
+            var context = trackedCommand.Metadata.GetContext<TestCustomContext>();
+            Assert.NotNull(context);
+            Assert.Equal("123", context.UserIdHeader);
+            Assert.True(context.ValidateOnlyHeader);
         }
 
         [Fact]


### PR DESCRIPTION
Added mechanism to set custom context in the command metadata via the command bus options object.